### PR TITLE
Modify mobile header bar width

### DIFF
--- a/fruit3/assets/css/style-m.css
+++ b/fruit3/assets/css/style-m.css
@@ -1,11 +1,14 @@
+:root {
+  --s-nav-width: 66vw;
+}
 .site-header {
   background: linear-gradient(
     45deg,
     #2A3288 0,
-    #2A3288 calc(35% - 8px),
-    #D0DF00 calc(35% - 8px),
-    #D0DF00 calc(35% + 8px),
-    #ffffff calc(35% + 8px),
+    #2A3288 calc(66% - 8px),
+    #D0DF00 calc(66% - 8px),
+    #D0DF00 calc(66% + 8px),
+    #ffffff calc(66% + 8px),
     #ffffff 100%
   );
 }

--- a/fruit3/assets/scss/style-m.scss
+++ b/fruit3/assets/scss/style-m.scss
@@ -1,0 +1,15 @@
+:root {
+  --s-nav-width: 66vw;
+}
+
+.site-header {
+  background: linear-gradient(
+    45deg,
+    #2A3288 0,
+    #2A3288 calc(66% - 8px),
+    #D0DF00 calc(66% - 8px),
+    #D0DF00 calc(66% + 8px),
+    #ffffff calc(66% + 8px),
+    #ffffff 100%
+  );
+}


### PR DESCRIPTION
## Summary
- adjust `style-m.css` and `style-m.scss` so the mobile navigation bar covers 66% of the header width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e3e2893148324994ec8d5b5a3293e