### PR TITLE
Update nav panel background in Fruit3

### DIFF
--- a/fruit3/assets/css/style-d.css
+++ b/fruit3/assets/css/style-d.css
@@ -13,3 +13,5 @@
 .s-nav>li>a{position:relative;height:auto}
 .s-nav>li>a::after{content:"";position:absolute;left:0;bottom:0;width:0;height:2px;background-color:var(--s-color-1);transition:width .3s ease}
 .s-nav>li>a:hover::after{width:100%}
+
+.nav-panel{background-color:var(--s-color-2);}

--- a/fruit3/assets/css/style-m.css
+++ b/fruit3/assets/css/style-m.css
@@ -32,3 +32,7 @@
     box-shadow: var(--s-shadow-1);
   }
 }
+
+.nav-panel {
+  background-color: var(--s-color-2);
+}

--- a/fruit3/assets/scss/style-d.scss
+++ b/fruit3/assets/scss/style-d.scss
@@ -16,3 +16,7 @@
     width: 100%;
   }
 }
+
+.nav-panel {
+  background-color: var(--s-color-2);
+}

--- a/fruit3/assets/scss/style-m.scss
+++ b/fruit3/assets/scss/style-m.scss
@@ -34,3 +34,7 @@
   }
 }
 
+.nav-panel {
+  background-color: var(--s-color-2);
+}
+


### PR DESCRIPTION
## Summary
- override nav panel background to use `--s-color-2`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860e092b4d4832490f3e2fe6dc971f1