### PR TITLE
Add floating header option

### DIFF
--- a/fruit3/assets/css/style-d.css
+++ b/fruit3/assets/css/style-d.css
@@ -48,3 +48,24 @@
   width: 100%;
 }
 
+.header--floating {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  z-index: 999;
+  transition: all 0.3s ease;
+}
+
+@media (min-width: 768px) {
+  .header--floating {
+    top: 16px;
+    left: 16px;
+    right: 16px;
+    border-radius: 12px;
+  }
+}
+

--- a/fruit3/assets/css/style-m.css
+++ b/fruit3/assets/css/style-m.css
@@ -36,3 +36,24 @@
 .nav-panel -right {
   background-color: var(--s-color-2);
 }
+
+.header--floating {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  z-index: 999;
+  transition: all 0.3s ease;
+}
+
+@media (min-width: 768px) {
+  .header--floating {
+    top: 16px;
+    left: 16px;
+    right: 16px;
+    border-radius: 12px;
+  }
+}

--- a/fruit3/assets/scss/style-d.scss
+++ b/fruit3/assets/scss/style-d.scss
@@ -31,3 +31,28 @@
 .s-nav > li.current_page_ancestor > a::after {
   width: 100%;
 }
+
+// Reusable mixin for a floating header option
+@mixin floating-header {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  z-index: 999;
+  transition: all 0.3s ease;
+
+  @media (min-width: 768px) {
+    top: 16px;
+    left: 16px;
+    right: 16px;
+    border-radius: 12px;
+  }
+}
+
+// Floating header class that can be toggled via Theme Options
+.header--floating {
+  @include floating-header();
+}

--- a/fruit3/assets/scss/style-m.scss
+++ b/fruit3/assets/scss/style-m.scss
@@ -38,3 +38,28 @@
   background-color: var(--s-color-2);
 }
 
+// Reusable mixin for a floating header option
+@mixin floating-header {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  z-index: 999;
+  transition: all 0.3s ease;
+
+  @media (min-width: 768px) {
+    top: 16px;
+    left: 16px;
+    right: 16px;
+    border-radius: 12px;
+  }
+}
+
+// Floating header class that can be toggled via Theme Options
+.header--floating {
+  @include floating-header();
+}
+

--- a/fruit3/functions.php
+++ b/fruit3/functions.php
@@ -16,3 +16,19 @@ add_action('wp_enqueue_scripts', 'fruit_scripts', 20);
 
 // DISABLE ACF IN PLANT
 // define('PLANT_DISABLE_ACF', true);
+
+// Add toggle option for floating header
+function fruit_customize_register($wp_customize)
+{
+    $wp_customize->add_setting('enable_floating_header', [
+        'default'           => false,
+        'sanitize_callback' => 'wp_validate_boolean',
+    ]);
+
+    $wp_customize->add_control('enable_floating_header', [
+        'label'   => __('Enable Floating Header', 'plant'),
+        'section' => 'header',
+        'type'    => 'checkbox',
+    ]);
+}
+add_action('customize_register', 'fruit_customize_register');

--- a/fruit3/header.php
+++ b/fruit3/header.php
@@ -18,7 +18,11 @@ echo plant_html_tag(); ?>>
         }
         if (get_theme_mod('set_topbar', false)) {
             get_template_part('parts/top-bar');
-        } ?>
+        }
+
+        $floating = get_theme_mod('enable_floating_header', false);
+        set_query_var('floating_header_class', $floating ? ' header--floating' : '');
+    ?>
     <?php get_template_part('parts/header', get_theme_mod('header_template', 'minimal-standard'));?>
     <div id="content" class="site-content">
         <div class="s-container">

--- a/fruit3/parts/header-center.php
+++ b/fruit3/parts/header-center.php
@@ -1,0 +1,70 @@
+<style>
+    :root {
+        --s-logo-space: 2.5rem;
+    }
+
+    .nav-inline {
+        flex: 1;
+    }
+
+    .nav-left {
+        justify-content: flex-end;
+        padding-right: var(--s-logo-space);
+    }
+
+    .nav-right {
+        justify-content: flex-start;
+        padding-left: var(--s-logo-space);
+    }
+
+    .site-header.active {
+        top: 0;
+    }
+</style>
+<header id="masthead" class="site-header<?php echo esc_attr( get_query_var('floating_header_class') ); ?>">
+    <div class="s-container">
+        <div class="site-action -left">
+            <?php echo plant_actions('left'); ?>
+        </div>
+        <nav class="nav-panel nav-inline nav-left _desktop">
+            <?php if(has_nav_menu('left')): ?>
+            <?php wp_nav_menu(['theme_location' => 'left','menu_class' => 's-nav']); ?>
+            <?php else: ?>
+            <div class="s-nav">
+                <small><code>Please add Left Menu via Appearance → Menus.</code></small>
+            </div>
+            <?php endif; ?>
+        </nav>
+        <div class="site-branding -center">
+            <?php echo plant_logo() . plant_title(); ?>
+        </div>
+        <nav class="nav-panel nav-inline nav-right _desktop">
+            <?php if(has_nav_menu('right')): ?>
+            <?php wp_nav_menu(['theme_location' => 'right','menu_class' => 's-nav']); ?>
+            <?php else: ?>
+            <div class="s-nav">
+                <small><code>Please add Right Menu via Appearance → Menus.</code></small>
+            </div>
+            <?php endif; ?>
+        </nav>
+        <div class="site-action -right">
+            <?php echo plant_actions('right'); ?>
+        </div>
+    </div>
+</header>
+<nav class="nav-panel <?php echo plant_nav_position()?>">
+    <div class="nav-toggle nav-close"><em></em></div>
+    <?php dynamic_sidebar('before_nav'); ?>
+    <?php if (has_nav_menu('mobile')) {
+        wp_nav_menu(['theme_location' => 'mobile',]);
+    } else {
+        wp_nav_menu(['theme_location' => 'primary',]);
+    }?>
+    <?php dynamic_sidebar('after_nav');?>
+</nav>
+<div class="search-panel">
+    <div class="s-container">
+        <?php echo plant_search_form(); ?>
+    </div>
+</div>
+<div class="site-header-space"></div>

--- a/fruit3/parts/header-classic.php
+++ b/fruit3/parts/header-classic.php
@@ -1,0 +1,108 @@
+<style>
+    @media(min-width: 1024px) {
+
+        .site-nav,
+        .search-panel {
+            --s-head-text: var(--s-nav-text);
+            --s-head-hover: var(--s-nav-hover);
+        }
+
+        .site-header .s-container {
+            height: unset;
+        }
+
+        .site-header .s-container>div {
+            display: flex;
+            align-items: center;
+        }
+
+        .header-classic>.s-container {
+            height: calc(var(--s-head-height) - var(--s-nav-height));
+        }
+
+        .site-header-center {
+            margin: 0 auto;
+        }
+
+        .site-header-right {
+            margin-left: auto;
+        }
+
+        .nav-inline {
+            margin-left: unset;
+            height: var(--s-nav-height);
+        }
+
+        .site-nav,
+        .s-nav .sub-menu,
+        .search-panel {
+            background: var(--s-nav-bg);
+        }
+
+        .s-nav .sub-menu::before {
+            border-bottom-color: var(--s-nav-bg);
+        }
+
+        .s-nav,
+        .s-nav a,
+        .search-panel {
+            color: var(--s-nav-text);
+        }
+
+        .s-nav li:hover>a,
+        .s-nav li:hover>.i-down,
+        .s-nav .sub-menu li:hover>a,
+        .s-nav .sub-menu li:hover>.i-down {
+            color: var(--s-nav-hover);
+        }
+
+        .site-action {
+            margin-left: auto;
+        }
+    }
+</style>
+<header id="masthead" class="site-header header-classic<?php echo esc_attr( get_query_var('floating_header_class') ); ?>">
+    <div class="s-container">
+        <div class="site-branding -left">
+            <?php echo plant_logo() . plant_title(); ?>
+        </div>
+        <div class="site-header-right _desktop">
+            <?php
+            $right = get_theme_mod('header_top_right_code', '[s_social]');
+            echo do_shortcode($right);
+            ?>
+        </div>
+        <div class="site-action -right _mobile">
+            <?php echo plant_actions('right'); ?>
+            <div class="nav-toggle -main"><em></em></div>
+        </div>
+    </div>
+    <div class="site-nav">
+        <div class="s-container">
+            <nav class="nav-panel -right nav-inline">
+                <?php dynamic_sidebar('before_nav'); ?>
+                <?php wp_nav_menu(['theme_location' => 'primary','menu_class'     => 's-nav']); ?>
+                <?php dynamic_sidebar('after_nav');?>
+            </nav>
+            <div class="site-action _desktop">
+                <?php echo plant_actions('right'); ?>
+            </div>
+        </div>
+    </div>
+</header>
+<nav class="nav-panel -right">
+    <div class="nav-toggle nav-close"><em></em></div>
+    <?php dynamic_sidebar('before_nav'); ?>
+    <?php if (has_nav_menu('mobile')) {
+        wp_nav_menu(['theme_location' => 'mobile',]);
+    } else {
+        wp_nav_menu(['theme_location' => 'primary',]);
+    }?>
+    <?php dynamic_sidebar('after_nav');?>
+</nav>
+<div class="search-panel">
+    <div class="s-container">
+        <?php echo plant_search_form(); ?>
+    </div>
+</div>
+<div class="site-header-space"></div>

--- a/fruit3/parts/header-leftbar.php
+++ b/fruit3/parts/header-leftbar.php
@@ -1,0 +1,105 @@
+<style>
+    @media(min-width: 1024px) {
+        .header-left {
+            --s-head-text: var(--s-nav-text);
+            position: fixed;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            overflow-y: auto;
+            overflow-x: hidden;
+            width: var(--s-nav-width);
+            color: var(--s-nav-text);
+            background: var(--s-nav-bg);
+            padding: 20px;
+            z-index: 8020;
+        }
+
+        .header-left a {
+            color: var(--s-nav-text);
+        }
+
+        .site-header {
+            background: none;
+            position: unset;
+            height: unset;
+        }
+
+        .site-header .s-container {
+            display: block;
+            height: unset;
+            padding: 0;
+        }
+
+        .nav-panel {
+            position: relative;
+            height: unset;
+            width: 100%;
+            left: 0;
+            opacity: 1;
+            padding-top: 20px;
+        }
+
+        .nav-panel ul {
+            padding: 0;
+        }
+
+        .nav-panel li {
+            width: 100%;
+        }
+
+        .site-content {
+            padding: 10px 0 0 var(--s-nav-width);
+        }
+
+        .site-footer {
+            padding-left: var(--s-nav-width);
+        }
+
+        .site-main .alignwide {
+            margin-left: 0;
+            margin-right: 0;
+        }
+
+        .site-main .alignfull {
+            margin-left: calc(-50vw + 50% + calc(var(--s-nav-width) / 2));
+            margin-right: calc(-50vw + 50% + calc(var(--s-nav-width) / 2));
+            max-width: calc(100vw - var(--s-nav-width));
+        }
+
+        .btn-edit {
+            left: unset;
+            right: 16px;
+        }
+    }
+</style>
+<div class="header-left">
+    <header id="masthead" class="site-header<?php echo esc_attr( get_query_var('floating_header_class') ); ?>">
+        <div class="s-container">
+            <div class="site-action -left _mobile">
+                <?php echo plant_actions('left'); ?>
+            </div>
+            <div class="site-branding -center">
+                <?php echo plant_logo() . plant_title(); ?>
+            </div>
+            <div class="site-action -right _mobile">
+                <?php echo plant_actions('right'); ?>
+            </div>
+        </div>
+    </header>
+    <nav class="nav-panel -left">
+        <div class="nav-toggle nav-close _mobile"><em></em></div>
+        <?php dynamic_sidebar('before_nav'); ?>
+        <?php if (has_nav_menu('mobile')) {
+            wp_nav_menu(['theme_location' => 'mobile',]);
+        } else {
+            wp_nav_menu(['theme_location' => 'primary',]);
+        }?>
+        <?php dynamic_sidebar('after_nav');?>
+    </nav>
+    <div class="search-panel">
+        <div class="s-container">
+            <?php echo plant_search_form(); ?>
+        </div>
+    </div>
+</div>

--- a/fruit3/parts/header-minimal-standard.php
+++ b/fruit3/parts/header-minimal-standard.php
@@ -1,0 +1,51 @@
+<?php // Standard (Logo Center on Mobile)?>
+<style>
+    .site-branding {
+        margin: 0 auto;
+    }
+
+    @media(min-width: 1024px) {
+        .site-branding {
+            margin: 0;
+        }
+
+        .site-action .nav-toggle {
+            display: none;
+        }
+    }
+</style>
+<header id="masthead" class="site-header<?php echo esc_attr( get_query_var('floating_header_class') ); ?>">
+    <div class="s-container">
+        <div class="site-action -left _mobile">
+            <?php echo plant_actions('left'); ?>
+        </div>
+        <div class="site-branding">
+            <?php echo plant_logo() . plant_title(); ?>
+        </div>
+        <nav class="nav-panel -right nav-inline _desktop">
+            <?php dynamic_sidebar('before_nav'); ?>
+            <?php wp_nav_menu(['theme_location' => 'primary','menu_class' => 's-nav']);?>
+            <?php dynamic_sidebar('after_nav');?>
+        </nav>
+        <div class="site-action -right">
+            <div class="site-action _desktop"><?php echo plant_actions('left'); ?></div>
+            <?php echo plant_actions('right'); ?>
+        </div>
+    </div>
+</header>
+<nav class="nav-panel _mobile <?php echo plant_nav_position()?>">
+    <div class="nav-toggle nav-close"><em></em></div>
+    <?php dynamic_sidebar('before_nav'); ?>
+    <?php if (has_nav_menu('mobile')) {
+        wp_nav_menu(['theme_location' => 'mobile',]);
+    } else {
+        wp_nav_menu(['theme_location' => 'primary',]);
+    }?>
+    <?php dynamic_sidebar('after_nav');?>
+</nav>
+<div class="search-panel">
+    <div class="s-container">
+        <?php echo plant_search_form(); ?>
+    </div>
+</div>
+<div class="site-header-space"></div>

--- a/fruit3/parts/header-shop.php
+++ b/fruit3/parts/header-shop.php
@@ -1,0 +1,50 @@
+<header id="masthead" class="site-header<?php echo esc_attr( get_query_var('floating_header_class') ); ?>">
+    <div class="s-container">
+        <div class="site-action -left _mobile">
+            <div class="nav-toggle"><em></em></div>
+        </div>
+        <div class="site-branding -center lg:m-0">
+            <?php echo plant_logo() . plant_title(); ?>
+        </div>
+        <div class="site-search">
+            <?php
+            $code = get_theme_mod('header_search_code', '[fibosearch]');
+            include_once(ABSPATH .'wp-admin/includes/plugin.php');
+            if ($code == '[fibosearch]') {
+                if (is_plugin_active('ajax-search-for-woocommerce/ajax-search-for-woocommerce.php')) {
+                    echo do_shortcode($code);
+                }
+            } else {
+                echo do_shortcode($code);
+            }
+            ?>
+        </div>
+        <nav class="nav-panel nav-inline">
+            <?php
+            dynamic_sidebar('before_nav');
+            wp_nav_menu(
+                [
+                    'theme_location' => 'primary',
+                    'menu_id'        => 'primary-menu',
+                    'menu_class'     => 's-nav'
+                ]
+            );
+            dynamic_sidebar('after_nav');
+            ?>
+        </nav>
+        <div class="site-action -right">
+            <?php echo plant_actions('shop'); ?>
+        </div>
+    </div>
+</header>
+<nav class="nav-panel <?php echo plant_nav_position()?>">
+    <div class="nav-toggle nav-close"><em></em></div>
+    <?php dynamic_sidebar('before_nav'); ?>
+    <?php if (has_nav_menu('mobile')) {
+        wp_nav_menu(['theme_location' => 'mobile',]);
+    } else {
+        wp_nav_menu(['theme_location' => 'primary',]);
+    }?>
+    <?php dynamic_sidebar('after_nav');?>
+</nav>
+<div class="site-header-space"></div>

--- a/fruit3/parts/header-standard-right.php
+++ b/fruit3/parts/header-standard-right.php
@@ -1,0 +1,58 @@
+<style>
+.site-branding {
+    margin: 0;
+    margin-left: auto;
+}
+
+@media(min-width: 1024px) {
+    .site-branding {
+        margin: 0;
+    }
+
+    .site-action .nav-toggle {
+        display: none;
+    }
+
+    .site-action.-left {
+        margin-left: var(--s-gap);
+        margin-right: 0;
+    }
+}
+</style>
+
+
+<header id="masthead" class="site-header<?php echo esc_attr( get_query_var('floating_header_class') ); ?>">
+    <div class="s-container">
+        <div class="site-branding">
+            <?php echo plant_logo() . plant_title(); ?>
+        </div>
+        <nav class="nav-panel -left nav-inline _desktop">
+            <?php
+            dynamic_sidebar('before_nav');
+            wp_nav_menu(['theme_location' => 'primary','menu_class'     => 's-nav']);
+            dynamic_sidebar('after_nav');
+            ?>
+        </nav>
+        <div class="site-action -left">
+            <div class="nav-toggle _mobile"><em></em></div>
+            <?php echo plant_actions('left');?>
+
+        </div>
+    </div>
+</header>
+<nav class="nav-panel -left">
+    <div class="nav-toggle nav-close"><em></em></div>
+    <?php dynamic_sidebar('before_nav'); ?>
+    <?php if (has_nav_menu('mobile')) {
+        wp_nav_menu(['theme_location' => 'mobile',]);
+    } else {
+        wp_nav_menu(['theme_location' => 'primary',]);
+    }?>
+    <?php dynamic_sidebar('after_nav');?>
+</nav>
+<div class="search-panel">
+    <div class="s-container">
+        <?php echo plant_search_form(); ?>
+    </div>
+</div>
+<div class="site-header-space"></div>

--- a/fruit3/parts/header-standard.php
+++ b/fruit3/parts/header-standard.php
@@ -1,0 +1,34 @@
+<header id="masthead" class="site-header<?php echo esc_attr( get_query_var('floating_header_class') ); ?>">
+    <div class="s-container">
+        <div class="site-branding">
+            <?php echo plant_logo() . plant_title(); ?>
+        </div>
+        <nav class="nav-panel -right nav-inline _desktop">
+            <?php
+            dynamic_sidebar('before_nav');
+            wp_nav_menu(['theme_location' => 'primary','menu_class'     => 's-nav']);
+            dynamic_sidebar('after_nav');
+            ?>
+        </nav>
+        <div class="site-action -right">
+            <?php echo plant_actions('right'); ?>
+            <div class="nav-toggle _mobile"><em></em></div>
+        </div>
+    </div>
+</header>
+<nav class="nav-panel -right">
+    <div class="nav-toggle nav-close"><em></em></div>
+    <?php dynamic_sidebar('before_nav'); ?>
+    <?php if (has_nav_menu('mobile')) {
+        wp_nav_menu(['theme_location' => 'mobile',]);
+    } else {
+        wp_nav_menu(['theme_location' => 'primary',]);
+    }?>
+    <?php dynamic_sidebar('after_nav');?>
+</nav>
+<div class="search-panel">
+    <div class="s-container">
+        <?php echo plant_search_form(); ?>
+    </div>
+</div>
+<div class="site-header-space"></div>

--- a/fruit3/parts/header-widget.php
+++ b/fruit3/parts/header-widget.php
@@ -1,0 +1,3 @@
+<header id="masthead" class="site-header-widget<?php echo esc_attr( get_query_var('floating_header_class') ); ?>">
+    <?php dynamic_sidebar('header'); ?>
+</header>

--- a/fruit3/parts/header.php
+++ b/fruit3/parts/header.php
@@ -1,0 +1,29 @@
+<header id="masthead" class="site-header<?php echo esc_attr( get_query_var('floating_header_class') ); ?>">
+    <div class="s-container">
+        <div class="site-action -left">
+            <?php echo plant_actions('left'); ?>
+        </div>
+        <div class="site-branding -center">
+            <?php echo plant_logo() . plant_title(); ?>
+        </div>
+        <div class="site-action -right">
+            <?php echo plant_actions('right'); ?>
+        </div>
+    </div>
+</header>
+<nav class="nav-panel <?php echo plant_nav_position()?>">
+    <div class="nav-toggle nav-close"><em></em></div>
+    <?php dynamic_sidebar('before_nav'); ?>
+    <?php if (has_nav_menu('mobile')) {
+        wp_nav_menu(['theme_location' => 'mobile',]);
+    } else {
+        wp_nav_menu(['theme_location' => 'primary',]);
+    }?>
+    <?php dynamic_sidebar('after_nav');?>
+</nav>
+<div class="search-panel">
+    <div class="s-container">
+        <?php echo plant_search_form(); ?>
+    </div>
+</div>
+<div class="site-header-space"></div>

--- a/fruit3/style.css
+++ b/fruit3/style.css
@@ -18,3 +18,5 @@ This theme use SCSS, please check
 */
 
 /* Custom header background layout via fruit3 child theme */
+/* Optional floating header class available via .header--floating */
+/* Toggle via Customizer → Header → Enable Floating Header */


### PR DESCRIPTION
## Summary
- allow enabling floating header from the Customizer
- pass `header--floating` class to header templates
- override default header templates to read floating option
- document customizer option in stylesheet
- apply floating header class to all header templates

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6864fd85be488324a6e105601cdaf4b5