### PR TITLE
Add solid floating header and dropdown mobile nav

### DIFF
--- a/fruit3/assets/css/style-d.css
+++ b/fruit3/assets/css/style-d.css
@@ -90,6 +90,31 @@
   transition: all 0.3s ease;
 }
 
+.header--floating.header--solid {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  background: linear-gradient(135deg, #2A3288 0, #2A3288 calc(35% - 8px), #D0DF00 calc(35% - 8px), #D0DF00 calc(35% + 8px), #ffffff calc(35% + 8px), #ffffff 100%);
+  box-shadow: var(--s-shadow-1);
+  border-radius: 8px;
+  z-index: 999;
+  transition: all 0.3s ease;
+  width: auto;
+  max-width: calc(100% - 16px);
+  margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+  .header--floating.header--solid {
+    top: 16px;
+    left: 16px;
+    right: 16px;
+    border-radius: 12px;
+    max-width: calc(100% - 32px);
+  }
+}
+
 @media (max-width: 767px) {
   .header--floating.header--blur {
     top: 12px;
@@ -98,5 +123,25 @@
     border-radius: 8px;
     max-width: calc(100% - 24px);
   }
+}
+
+.nav-panel.-dropdown {
+  position: absolute;
+  top: var(--s-head-height);
+  left: 0;
+  right: 0;
+  width: 100%;
+  max-height: 0;
+  overflow: hidden;
+  padding: 0 var(--s-space);
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+  background-color: var(--s-nav-bg);
+}
+
+.nav-panel.-dropdown.active {
+  max-height: 80vh;
+  opacity: 1;
+  box-shadow: var(--s-shadow-1);
 }
 

--- a/fruit3/assets/css/style-m.css
+++ b/fruit3/assets/css/style-m.css
@@ -37,6 +37,26 @@
   background-color: var(--s-color-2);
 }
 
+.nav-panel.-dropdown {
+  position: absolute;
+  top: var(--s-head-height);
+  left: 0;
+  right: 0;
+  width: 100%;
+  max-height: 0;
+  overflow: hidden;
+  padding: 0 var(--s-space);
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+  background-color: var(--s-nav-bg);
+}
+
+.nav-panel.-dropdown.active {
+  max-height: 80vh;
+  opacity: 1;
+  box-shadow: var(--s-shadow-1);
+}
+
 .header--floating {
   position: fixed;
   top: 8px;
@@ -77,6 +97,32 @@
   max-width: calc(100% - 32px);
   margin: 0 auto;
   transition: all 0.3s ease;
+}
+
+.header--floating.header--solid {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  background: linear-gradient(135deg, #2A3288 0, #2A3288 calc(66% - 8px), #D0DF00 calc(66% - 8px), #D0DF00 calc(66% + 8px), #ffffff calc(66% + 8px), #ffffff 100%);
+  box-shadow: var(--s-shadow-1);
+  border-radius: 8px;
+  z-index: 999;
+  transition: all 0.3s ease;
+  width: auto;
+  max-width: calc(100% - 16px);
+  margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+  .header--floating.header--solid {
+    top: 16px;
+    left: 16px;
+    right: 16px;
+    border-radius: 12px;
+    max-width: calc(100% - 32px);
+    background: linear-gradient(135deg, #2A3288 0, #2A3288 calc(35% - 8px), #D0DF00 calc(35% - 8px), #D0DF00 calc(35% + 8px), #ffffff calc(35% + 8px), #ffffff 100%);
+  }
 }
 
 @media (max-width: 767px) {

--- a/fruit3/assets/scss/style-d.scss
+++ b/fruit3/assets/scss/style-d.scss
@@ -81,6 +81,37 @@
   }
 }
 
+@mixin floating-header-solid {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  background: linear-gradient(
+    135deg,
+    #2A3288 0,
+    #2A3288 calc(35% - 8px),
+    #D0DF00 calc(35% - 8px),
+    #D0DF00 calc(35% + 8px),
+    #ffffff calc(35% + 8px),
+    #ffffff 100%
+  );
+  box-shadow: var(--s-shadow-1);
+  border-radius: 8px;
+  z-index: 999;
+  transition: all 0.3s ease;
+  width: auto;
+  max-width: calc(100% - 16px);
+  margin: 0 auto;
+
+  @media (min-width: 768px) {
+    top: 16px;
+    left: 16px;
+    right: 16px;
+    border-radius: 12px;
+    max-width: calc(100% - 32px);
+  }
+}
+
 // Floating header class that can be toggled via Theme Options
 .header--floating {
   @include floating-header();
@@ -88,4 +119,28 @@
 
 .header--floating.header--blur {
   @include floating-header-blur();
+}
+
+.header--floating.header--solid {
+  @include floating-header-solid();
+}
+
+.nav-panel.-dropdown {
+  position: absolute;
+  top: var(--s-head-height);
+  left: 0;
+  right: 0;
+  width: 100%;
+  max-height: 0;
+  overflow: hidden;
+  padding: 0 var(--s-space);
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+  background-color: var(--s-nav-bg);
+}
+
+.nav-panel.-dropdown.active {
+  max-height: 80vh;
+  opacity: 1;
+  box-shadow: var(--s-shadow-1);
 }

--- a/fruit3/assets/scss/style-m.scss
+++ b/fruit3/assets/scss/style-m.scss
@@ -38,6 +38,26 @@
   background-color: var(--s-color-2);
 }
 
+.nav-panel.-dropdown {
+  position: absolute;
+  top: var(--s-head-height);
+  left: 0;
+  right: 0;
+  width: 100%;
+  max-height: 0;
+  overflow: hidden;
+  padding: 0 var(--s-space);
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+  background-color: var(--s-nav-bg);
+}
+
+.nav-panel.-dropdown.active {
+  max-height: 80vh;
+  opacity: 1;
+  box-shadow: var(--s-shadow-1);
+}
+
 // Reusable mixin for a floating header option
 @mixin floating-header {
   position: fixed;
@@ -87,6 +107,46 @@
   }
 }
 
+@mixin floating-header-solid {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  background: linear-gradient(
+    135deg,
+    #2A3288 0,
+    #2A3288 calc(66% - 8px),
+    #D0DF00 calc(66% - 8px),
+    #D0DF00 calc(66% + 8px),
+    #ffffff calc(66% + 8px),
+    #ffffff 100%
+  );
+  box-shadow: var(--s-shadow-1);
+  border-radius: 8px;
+  z-index: 999;
+  transition: all 0.3s ease;
+  width: auto;
+  max-width: calc(100% - 16px);
+  margin: 0 auto;
+
+  @media (min-width: 768px) {
+    top: 16px;
+    left: 16px;
+    right: 16px;
+    border-radius: 12px;
+    max-width: calc(100% - 32px);
+    background: linear-gradient(
+      135deg,
+      #2A3288 0,
+      #2A3288 calc(35% - 8px),
+      #D0DF00 calc(35% - 8px),
+      #D0DF00 calc(35% + 8px),
+      #ffffff calc(35% + 8px),
+      #ffffff 100%
+    );
+  }
+}
+
 // Floating header class that can be toggled via Theme Options
 .header--floating {
   @include floating-header();
@@ -94,5 +154,9 @@
 
 .header--floating.header--blur {
   @include floating-header-blur();
+}
+
+.header--floating.header--solid {
+  @include floating-header-solid();
 }
 

--- a/fruit3/functions.php
+++ b/fruit3/functions.php
@@ -32,6 +32,7 @@ function fruit_customize_register($wp_customize)
         'choices'  => [
             'none'  => __('None', 'plant'),
             'basic' => __('Transparent', 'plant'),
+            'solid' => __('Solid', 'plant'),
             'blur'  => __('Blur Dark', 'plant'),
         ],
         'priority' => 40,

--- a/fruit3/header.php
+++ b/fruit3/header.php
@@ -26,6 +26,8 @@ echo plant_html_tag(); ?>>
             $classes = ' header--floating';
             if ($style === 'blur') {
                 $classes .= ' header--blur';
+            } elseif ($style === 'solid') {
+                $classes .= ' header--solid';
             }
         }
         set_query_var('floating_header_class', $classes);

--- a/fruit3/parts/header-center.php
+++ b/fruit3/parts/header-center.php
@@ -52,7 +52,7 @@
         </div>
     </div>
 </header>
-<nav class="nav-panel <?php echo plant_nav_position()?>">
+<nav class="nav-panel <?php echo plant_nav_position()?> -dropdown">
     <div class="nav-toggle nav-close"><em></em></div>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {

--- a/fruit3/parts/header-classic.php
+++ b/fruit3/parts/header-classic.php
@@ -90,7 +90,7 @@
         </div>
     </div>
 </header>
-<nav class="nav-panel -right">
+<nav class="nav-panel -right -dropdown">
     <div class="nav-toggle nav-close"><em></em></div>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {

--- a/fruit3/parts/header-leftbar.php
+++ b/fruit3/parts/header-leftbar.php
@@ -87,7 +87,7 @@
             </div>
         </div>
     </header>
-    <nav class="nav-panel -left">
+    <nav class="nav-panel -left -dropdown">
         <div class="nav-toggle nav-close _mobile"><em></em></div>
         <?php dynamic_sidebar('before_nav'); ?>
         <?php if (has_nav_menu('mobile')) {

--- a/fruit3/parts/header-minimal-standard.php
+++ b/fruit3/parts/header-minimal-standard.php
@@ -33,7 +33,7 @@
         </div>
     </div>
 </header>
-<nav class="nav-panel _mobile <?php echo plant_nav_position()?>">
+<nav class="nav-panel _mobile <?php echo plant_nav_position()?> -dropdown">
     <div class="nav-toggle nav-close"><em></em></div>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {

--- a/fruit3/parts/header-shop.php
+++ b/fruit3/parts/header-shop.php
@@ -37,7 +37,7 @@
         </div>
     </div>
 </header>
-<nav class="nav-panel <?php echo plant_nav_position()?>">
+<nav class="nav-panel <?php echo plant_nav_position()?> -dropdown">
     <div class="nav-toggle nav-close"><em></em></div>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {

--- a/fruit3/parts/header-standard-right.php
+++ b/fruit3/parts/header-standard-right.php
@@ -40,7 +40,7 @@
         </div>
     </div>
 </header>
-<nav class="nav-panel -left">
+<nav class="nav-panel -left -dropdown">
     <div class="nav-toggle nav-close"><em></em></div>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {

--- a/fruit3/parts/header-standard.php
+++ b/fruit3/parts/header-standard.php
@@ -16,7 +16,7 @@
         </div>
     </div>
 </header>
-<nav class="nav-panel -right">
+<nav class="nav-panel -right -dropdown">
     <div class="nav-toggle nav-close"><em></em></div>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {

--- a/fruit3/parts/header.php
+++ b/fruit3/parts/header.php
@@ -11,7 +11,7 @@
         </div>
     </div>
 </header>
-<nav class="nav-panel <?php echo plant_nav_position()?>">
+<nav class="nav-panel <?php echo plant_nav_position()?> -dropdown">
     <div class="nav-toggle nav-close"><em></em></div>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {

--- a/fruit3/style.css
+++ b/fruit3/style.css
@@ -20,3 +20,4 @@ This theme use SCSS, please check
 /* Custom header background layout via fruit3 child theme */
 /* Optional floating header classes available via .header--floating */
 /* Choose style via Customizer → Header → Floating Header Style */
+/* Available styles: None, Transparent, Solid, Blur Dark */


### PR DESCRIPTION
## Summary
- add `solid` option for floating header style
- support new `header--solid` class
- implement dropdown mobile nav panel
- update child theme CSS/SCSS and header templates

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6865171050f08324bc36b876b07d11cc