### PR TITLE
Adjust dropdown and header styles

### DIFF
--- a/fruit3/assets/css/style-d.css
+++ b/fruit3/assets/css/style-d.css
@@ -61,6 +61,8 @@
   width: auto;
   max-width: calc(100% - 16px);
   margin: 0 auto;
+  --s-head-text: var(--s-color-2);
+  --s-head-hover: var(--s-color-1);
 }
 
 @media (min-width: 768px) {
@@ -86,6 +88,8 @@
   padding: 0;
   width: auto;
   max-width: calc(100% - 32px);
+  --s-head-text: #fff;
+  --s-head-hover: #fff;
   margin: 0 auto;
   transition: all 0.3s ease;
 }
@@ -175,6 +179,8 @@
   margin: 0 auto;
   border-radius: 0 0 8px 8px;
   background: rgba(255, 255, 255, 0.92);
+  --s-nav-text: var(--s-color-2);
+  --s-nav-hover: var(--s-color-1);
 }
 
 @media (min-width: 768px) {
@@ -189,20 +195,26 @@
 
 .header--floating.header--solid + .nav-panel.-dropdown {
   background: #ffffff;
+  --s-nav-text: var(--s-color-2);
+  --s-nav-hover: var(--s-color-1);
 }
 
 .header--floating.header--glass + .nav-panel.-dropdown {
   backdrop-filter: blur(6px);
   background: #ffffff;
+  --s-nav-text: var(--s-color-2);
+  --s-nav-hover: var(--s-color-1);
 }
 
 .header--floating.header--blur + .nav-panel.-dropdown {
   backdrop-filter: blur(6px);
   background-color: rgba(34,34,34,0.92);
+  --s-nav-text: #fff;
+  --s-nav-hover: #fff;
 }
 
 .nav-panel.-dropdown.active {
-  max-height: 80vh;
+  max-height: none;
   opacity: 1;
   box-shadow: var(--s-shadow-1);
 }

--- a/fruit3/assets/css/style-m.css
+++ b/fruit3/assets/css/style-m.css
@@ -61,6 +61,8 @@
   margin: 0 auto;
   border-radius: 0 0 8px 8px;
   background: rgba(255, 255, 255, 0.92);
+  --s-nav-text: var(--s-color-2);
+  --s-nav-hover: var(--s-color-1);
 }
 
 @media (min-width: 768px) {
@@ -75,20 +77,26 @@
 
 .header--floating.header--solid + .nav-panel.-dropdown {
   background: #ffffff;
+  --s-nav-text: var(--s-color-2);
+  --s-nav-hover: var(--s-color-1);
 }
 
 .header--floating.header--glass + .nav-panel.-dropdown {
   backdrop-filter: blur(6px);
   background: #ffffff;
+  --s-nav-text: var(--s-color-2);
+  --s-nav-hover: var(--s-color-1);
 }
 
 .header--floating.header--blur + .nav-panel.-dropdown {
   backdrop-filter: blur(6px);
   background-color: rgba(34, 34, 34, 0.92);
+  --s-nav-text: #fff;
+  --s-nav-hover: #fff;
 }
 
 .nav-panel.-dropdown.active {
-  max-height: 80vh;
+  max-height: none;
   opacity: 1;
   box-shadow: var(--s-shadow-1);
 }
@@ -106,6 +114,8 @@
   width: auto;
   max-width: calc(100% - 16px);
   margin: 0 auto;
+  --s-head-text: var(--s-color-2);
+  --s-head-hover: var(--s-color-1);
 }
 
 @media (min-width: 768px) {
@@ -131,6 +141,8 @@
   padding: 0;
   width: auto;
   max-width: calc(100% - 32px);
+  --s-head-text: #fff;
+  --s-head-hover: #fff;
   margin: 0 auto;
   transition: all 0.3s ease;
 }

--- a/fruit3/assets/js/main.js
+++ b/fruit3/assets/js/main.js
@@ -1,0 +1,18 @@
+// Adjust dropdown height to match content
+document.addEventListener('DOMContentLoaded', function () {
+  const dropdown = document.querySelector('.nav-panel.-dropdown');
+  if (!dropdown) return;
+
+  const updateHeight = () => {
+    if (dropdown.classList.contains('active')) {
+      dropdown.style.maxHeight = dropdown.scrollHeight + 'px';
+    } else {
+      dropdown.style.maxHeight = '';
+    }
+  };
+
+  const observer = new MutationObserver(updateHeight);
+  observer.observe(dropdown, { attributes: true, attributeFilter: ['class'] });
+
+  updateHeight();
+});

--- a/fruit3/assets/scss/style-d.scss
+++ b/fruit3/assets/scss/style-d.scss
@@ -145,12 +145,18 @@
 }
 
 // Floating header class that can be toggled via Theme Options
+
+// Floating header class that can be toggled via Theme Options
 .header--floating {
   @include floating-header();
+  --s-head-text: var(--s-color-2);
+  --s-head-hover: var(--s-color-1);
 }
 
 .header--floating.header--blur {
   @include floating-header-blur();
+  --s-head-text: #fff;
+  --s-head-hover: #fff;
 }
 
 .header--floating.header--solid {
@@ -185,6 +191,8 @@
   margin: 0 auto;
   border-radius: 0 0 8px 8px;
   background: rgba(255, 255, 255, 0.92);
+  --s-nav-text: var(--s-color-2);
+  --s-nav-hover: var(--s-color-1);
 }
 
 @media (min-width: 768px) {
@@ -199,20 +207,26 @@
 
 .header--floating.header--solid + .nav-panel.-dropdown {
   background: #ffffff;
+  --s-nav-text: var(--s-color-2);
+  --s-nav-hover: var(--s-color-1);
 }
 
 .header--floating.header--glass + .nav-panel.-dropdown {
   backdrop-filter: blur(6px);
   background: #ffffff;
+  --s-nav-text: var(--s-color-2);
+  --s-nav-hover: var(--s-color-1);
 }
 
 .header--floating.header--blur + .nav-panel.-dropdown {
   backdrop-filter: blur(6px);
   background-color: rgba(34, 34, 34, 0.92);
+  --s-nav-text: #fff;
+  --s-nav-hover: #fff;
 }
 
 .nav-panel.-dropdown.active {
-  max-height: 80vh;
+  max-height: none;
   opacity: 1;
   box-shadow: var(--s-shadow-1);
 }

--- a/fruit3/assets/scss/style-m.scss
+++ b/fruit3/assets/scss/style-m.scss
@@ -62,6 +62,8 @@
   margin: 0 auto;
   border-radius: 0 0 8px 8px;
   background: rgba(255, 255, 255, 0.92);
+  --s-nav-text: var(--s-color-2);
+  --s-nav-hover: var(--s-color-1);
 }
 
 @media (min-width: 768px) {
@@ -76,20 +78,26 @@
 
 .header--floating.header--solid + .nav-panel.-dropdown {
   background: #ffffff;
+  --s-nav-text: var(--s-color-2);
+  --s-nav-hover: var(--s-color-1);
 }
 
 .header--floating.header--glass + .nav-panel.-dropdown {
   backdrop-filter: blur(6px);
   background: #ffffff;
+  --s-nav-text: var(--s-color-2);
+  --s-nav-hover: var(--s-color-1);
 }
 
 .header--floating.header--blur + .nav-panel.-dropdown {
   backdrop-filter: blur(6px);
   background-color: rgba(34, 34, 34, 0.92);
+  --s-nav-text: #fff;
+  --s-nav-hover: #fff;
 }
 
 .nav-panel.-dropdown.active {
-  max-height: 80vh;
+  max-height: none;
   opacity: 1;
   box-shadow: var(--s-shadow-1);
 }
@@ -227,10 +235,14 @@
 // Floating header class that can be toggled via Theme Options
 .header--floating {
   @include floating-header();
+  --s-head-text: var(--s-color-2);
+  --s-head-hover: var(--s-color-1);
 }
 
 .header--floating.header--blur {
   @include floating-header-blur();
+  --s-head-text: #fff;
+  --s-head-hover: #fff;
 }
 
 .header--floating.header--solid {


### PR DESCRIPTION
## Summary
- tweak floating header variables for light/dark modes
- set dropdown nav color variables
- remove fixed max-height and add JS auto sizing for dropdown

## Testing
- `php` lint *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686539b94a948324ab537d158ebfb91c