### PR TITLE
Update mobile floating menu

### DIFF
--- a/fruit3/assets/css/style-d.css
+++ b/fruit3/assets/css/style-d.css
@@ -55,7 +55,8 @@
   right: 8px;
   background: rgba(255, 255, 255, 0.92);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  border-radius: 8px;
+  --floating-radius: 8px;
+  border-radius: var(--floating-radius);
   z-index: 999;
   transition: all 0.3s ease;
   width: auto;
@@ -70,7 +71,8 @@
     top: 16px;
     left: 16px;
     right: 16px;
-    border-radius: 12px;
+    --floating-radius: 12px;
+    border-radius: var(--floating-radius);
     max-width: calc(100% - 32px);
   }
 }
@@ -156,6 +158,7 @@
 }
 
 .nav-panel.-dropdown {
+  display: none;
   position: absolute;
   top: var(--s-head-height);
   left: 0;
@@ -170,6 +173,7 @@
 }
 
 .header--floating + .nav-panel.-dropdown {
+  display: block;
   position: fixed;
   top: calc(var(--s-head-height) + 8px);
   left: 8px;
@@ -177,7 +181,7 @@
   width: auto;
   max-width: calc(100% - 16px);
   margin: 0 auto;
-  border-radius: 0 0 8px 8px;
+  border-radius: var(--floating-radius);
   background: rgba(255, 255, 255, 0.92);
   --s-nav-text: var(--s-color-2);
   --s-nav-hover: var(--s-color-1);
@@ -189,7 +193,7 @@
     left: 16px;
     right: 16px;
     max-width: calc(100% - 32px);
-    border-radius: 0 0 12px 12px;
+    border-radius: var(--floating-radius);
   }
 }
 
@@ -214,7 +218,7 @@
 }
 
 .nav-panel.-dropdown.active {
-  max-height: none;
+  max-height: var(--dropdown-height);
   opacity: 1;
   box-shadow: var(--s-shadow-1);
 }

--- a/fruit3/assets/css/style-m.css
+++ b/fruit3/assets/css/style-m.css
@@ -38,6 +38,7 @@
 }
 
 .nav-panel.-dropdown {
+  display: none;
   position: absolute;
   top: var(--s-head-height);
   left: 0;
@@ -52,6 +53,7 @@
 }
 
 .header--floating + .nav-panel.-dropdown {
+  display: block;
   position: fixed;
   top: calc(var(--s-head-height) + 16px);
   left: 50%;
@@ -59,7 +61,7 @@
   width: auto;
   max-width: calc(100% - 16px);
   margin: 0 auto;
-  border-radius: 0 0 8px 8px;
+  border-radius: var(--floating-radius);
   background: rgba(255, 255, 255, 0.92);
   --s-nav-text: var(--s-color-2);
   --s-nav-hover: var(--s-color-1);
@@ -71,7 +73,7 @@
     left: 50%;
     transform: translateX(-50%);
     max-width: calc(100% - 32px);
-    border-radius: 0 0 12px 12px;
+    border-radius: var(--floating-radius);
   }
 }
 
@@ -96,7 +98,7 @@
 }
 
 .nav-panel.-dropdown.active {
-  max-height: none;
+  max-height: var(--dropdown-height);
   opacity: 1;
   box-shadow: var(--s-shadow-1);
 }
@@ -108,7 +110,8 @@
   right: 8px;
   background: rgba(255, 255, 255, 0.92);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  border-radius: 8px;
+  --floating-radius: 8px;
+  border-radius: var(--floating-radius);
   z-index: 999;
   transition: all 0.3s ease;
   width: auto;
@@ -123,7 +126,8 @@
     top: 16px;
     left: 16px;
     right: 16px;
-    border-radius: 12px;
+    --floating-radius: 12px;
+    border-radius: var(--floating-radius);
     max-width: calc(100% - 32px);
   }
 }
@@ -240,6 +244,7 @@
   .header--floating + .nav-panel.-dropdown.active {
     opacity: 1;
     transform: translateY(0);
+    max-height: var(--dropdown-height);
   }
 
   .header--floating + .nav-panel.-dropdown .nav-close {

--- a/fruit3/assets/js/main.js
+++ b/fruit3/assets/js/main.js
@@ -1,13 +1,14 @@
 // Adjust dropdown height to match content
 document.addEventListener('DOMContentLoaded', function () {
+  const header = document.querySelector('.header--floating');
   const dropdown = document.querySelector('.nav-panel.-dropdown');
-  if (!dropdown) return;
+  if (!header || !dropdown) return;
 
   const updateHeight = () => {
     if (dropdown.classList.contains('active')) {
-      dropdown.style.maxHeight = dropdown.scrollHeight + 'px';
+      dropdown.style.setProperty('--dropdown-height', dropdown.scrollHeight + 'px');
     } else {
-      dropdown.style.maxHeight = '';
+      dropdown.style.removeProperty('--dropdown-height');
     }
   };
 

--- a/fruit3/assets/scss/style-d.scss
+++ b/fruit3/assets/scss/style-d.scss
@@ -40,7 +40,8 @@
   right: 8px;
   background: rgba(255, 255, 255, 0.92);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  border-radius: 8px;
+  --floating-radius: 8px;
+  border-radius: var(--floating-radius);
   z-index: 999;
   transition: all 0.3s ease;
   width: auto;
@@ -51,7 +52,8 @@
     top: 16px;
     left: 16px;
     right: 16px;
-    border-radius: 12px;
+    --floating-radius: 12px;
+    border-radius: var(--floating-radius);
     max-width: calc(100% - 32px);
   }
 }
@@ -168,6 +170,7 @@
 }
 
 .nav-panel.-dropdown {
+  display: none;
   position: absolute;
   top: var(--s-head-height);
   left: 0;
@@ -182,6 +185,7 @@
 }
 
 .header--floating + .nav-panel.-dropdown {
+  display: block;
   position: fixed;
   top: calc(var(--s-head-height) + 8px);
   left: 8px;
@@ -189,7 +193,7 @@
   width: auto;
   max-width: calc(100% - 16px);
   margin: 0 auto;
-  border-radius: 0 0 8px 8px;
+  border-radius: var(--floating-radius);
   background: rgba(255, 255, 255, 0.92);
   --s-nav-text: var(--s-color-2);
   --s-nav-hover: var(--s-color-1);
@@ -201,7 +205,7 @@
     left: 16px;
     right: 16px;
     max-width: calc(100% - 32px);
-    border-radius: 0 0 12px 12px;
+    border-radius: var(--floating-radius);
   }
 }
 
@@ -226,7 +230,7 @@
 }
 
 .nav-panel.-dropdown.active {
-  max-height: none;
+  max-height: var(--dropdown-height);
   opacity: 1;
   box-shadow: var(--s-shadow-1);
 }

--- a/fruit3/assets/scss/style-m.scss
+++ b/fruit3/assets/scss/style-m.scss
@@ -39,6 +39,7 @@
 }
 
 .nav-panel.-dropdown {
+  display: none;
   position: absolute;
   top: var(--s-head-height);
   left: 0;
@@ -54,6 +55,7 @@
 
 // Floating header dropdown with extra spacing
 .header--floating + .nav-panel.-dropdown {
+  display: block;
   position: fixed;
   top: calc(var(--s-head-height) + 16px);
   left: 50%;
@@ -61,7 +63,7 @@
   width: auto;
   max-width: calc(100% - 16px);
   margin: 0 auto;
-  border-radius: 0 0 8px 8px;
+  border-radius: var(--floating-radius);
   background: rgba(255, 255, 255, 0.92);
   --s-nav-text: var(--s-color-2);
   --s-nav-hover: var(--s-color-1);
@@ -73,7 +75,7 @@
     left: 50%;
     transform: translateX(-50%);
     max-width: calc(100% - 32px);
-    border-radius: 0 0 12px 12px;
+    border-radius: var(--floating-radius);
   }
 }
 
@@ -98,7 +100,7 @@
 }
 
 .nav-panel.-dropdown.active {
-  max-height: none;
+  max-height: var(--dropdown-height);
   opacity: 1;
   box-shadow: var(--s-shadow-1);
 }
@@ -111,7 +113,8 @@
   right: 8px;
   background: rgba(255, 255, 255, 0.92);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  border-radius: 8px;
+  --floating-radius: 8px;
+  border-radius: var(--floating-radius);
   z-index: 999;
   transition: all 0.3s ease;
   width: auto;
@@ -122,7 +125,8 @@
     top: 16px;
     left: 16px;
     right: 16px;
-    border-radius: 12px;
+    --floating-radius: 12px;
+    border-radius: var(--floating-radius);
     max-width: calc(100% - 32px);
   }
 }
@@ -236,6 +240,8 @@
 // Floating header class that can be toggled via Theme Options
 .header--floating {
   @include floating-header();
+  --floating-radius: 8px;
+  border-radius: var(--floating-radius);
   --s-head-text: var(--s-color-2);
   --s-head-hover: var(--s-color-1);
 }
@@ -267,7 +273,7 @@
     margin: 0 auto;
     padding: var(--s-space);
     opacity: 0;
-    border-radius: var(--s-rounded-2);
+    border-radius: var(--floating-radius);
     box-shadow: var(--s-shadow-2);
     transition: transform 0.3s ease, opacity 0.3s ease;
   }
@@ -278,13 +284,14 @@
       right: 16px;
       max-width: calc(100% - 32px);
       transform: translateY(-12px);
-      border-radius: var(--s-rounded-3);
+      border-radius: var(--floating-radius);
     }
   }
 
   .header--floating + .nav-panel.-dropdown.active {
     opacity: 1;
     transform: translateY(0);
+    max-height: var(--dropdown-height);
   }
 
   .header--floating + .nav-panel.-dropdown .nav-close {

--- a/fruit3/parts/header.php
+++ b/fruit3/parts/header.php
@@ -11,8 +11,13 @@
         </div>
     </div>
 </header>
+<?php $floating = get_query_var('floating_header_class'); ?>
 <nav class="nav-panel <?php echo plant_nav_position()?> -dropdown">
+    <?php if ($floating): ?>
+    <div class="nav-close"><em></em></div>
+    <?php else: ?>
     <div class="nav-toggle nav-close"><em></em></div>
+    <?php endif; ?>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {
         wp_nav_menu(['theme_location' => 'mobile',]);


### PR DESCRIPTION
## Summary
- tweak mobile dropdown CSS for floating header
- set dropdown height from JS only when floating header exists
- share header radius with dropdown
- remove toggle class from floating nav close

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6865ee8a06708324a6fbc9b6dbe1e013