### PR TITLE
Fix non-floating header mobile menu

### DIFF
--- a/fruit3/assets/css/style-d.css
+++ b/fruit3/assets/css/style-d.css
@@ -159,7 +159,7 @@
 
 .nav-panel.-dropdown {
   display: none;
-  position: absolute;
+  position: fixed;
   top: var(--s-head-height);
   left: 0;
   right: 0;
@@ -168,6 +168,7 @@
   overflow: hidden;
   padding: 0 var(--s-space);
   opacity: 0;
+  z-index: 8000;
   transition: max-height 0.4s cubic-bezier(.4,0,.2,1), opacity 0.3s ease;
   background-color: var(--s-nav-bg);
 }

--- a/fruit3/assets/css/style-m.css
+++ b/fruit3/assets/css/style-m.css
@@ -39,7 +39,7 @@
 
 .nav-panel.-dropdown {
   display: none;
-  position: absolute;
+  position: fixed;
   top: var(--s-head-height);
   left: 0;
   right: 0;
@@ -48,6 +48,7 @@
   overflow: hidden;
   padding: 0 var(--s-space);
   opacity: 0;
+  z-index: 8000;
   transition: max-height 0.4s cubic-bezier(.4,0,.2,1), opacity 0.3s ease;
   background-color: var(--s-nav-bg);
 }


### PR DESCRIPTION
## Summary
- keep nav panel fixed for non-floating headers

## Testing
- `php -l fruit3/functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866418652a08324b6c364c155217b45