### PR TITLE
Fix floating header close

### DIFF
--- a/fruit3/assets/css/style-m.css
+++ b/fruit3/assets/css/style-m.css
@@ -249,12 +249,6 @@
     max-height: var(--dropdown-height);
   }
 
-  .header--floating + .nav-panel.-dropdown .nav-close {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-  }
-
   .header--floating + .nav-panel.-dropdown ul {
     display: flex;
     flex-direction: column;

--- a/fruit3/assets/scss/style-m.scss
+++ b/fruit3/assets/scss/style-m.scss
@@ -295,12 +295,6 @@
     max-height: var(--dropdown-height);
   }
 
-  .header--floating + .nav-panel.-dropdown .nav-close {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-  }
-
   .header--floating + .nav-panel.-dropdown ul {
     display: flex;
     flex-direction: column;

--- a/fruit3/parts/header-center.php
+++ b/fruit3/parts/header-center.php
@@ -52,8 +52,11 @@
         </div>
     </div>
 </header>
+<?php $floating = get_query_var('floating_header_class'); ?>
 <nav class="nav-panel <?php echo plant_nav_position()?> -dropdown">
+    <?php if (!$floating): ?>
     <div class="nav-toggle nav-close"><em></em></div>
+    <?php endif; ?>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {
         wp_nav_menu(['theme_location' => 'mobile',]);

--- a/fruit3/parts/header-classic.php
+++ b/fruit3/parts/header-classic.php
@@ -90,8 +90,11 @@
         </div>
     </div>
 </header>
+<?php $floating = get_query_var('floating_header_class'); ?>
 <nav class="nav-panel -right -dropdown">
+    <?php if (!$floating): ?>
     <div class="nav-toggle nav-close"><em></em></div>
+    <?php endif; ?>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {
         wp_nav_menu(['theme_location' => 'mobile',]);

--- a/fruit3/parts/header-leftbar.php
+++ b/fruit3/parts/header-leftbar.php
@@ -87,8 +87,11 @@
             </div>
         </div>
     </header>
+    <?php $floating = get_query_var('floating_header_class'); ?>
     <nav class="nav-panel -left -dropdown">
+        <?php if (!$floating): ?>
         <div class="nav-toggle nav-close _mobile"><em></em></div>
+        <?php endif; ?>
         <?php dynamic_sidebar('before_nav'); ?>
         <?php if (has_nav_menu('mobile')) {
             wp_nav_menu(['theme_location' => 'mobile',]);

--- a/fruit3/parts/header-minimal-standard.php
+++ b/fruit3/parts/header-minimal-standard.php
@@ -33,8 +33,11 @@
         </div>
     </div>
 </header>
+<?php $floating = get_query_var('floating_header_class'); ?>
 <nav class="nav-panel _mobile <?php echo plant_nav_position()?> -dropdown">
+    <?php if (!$floating): ?>
     <div class="nav-toggle nav-close"><em></em></div>
+    <?php endif; ?>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {
         wp_nav_menu(['theme_location' => 'mobile',]);

--- a/fruit3/parts/header-shop.php
+++ b/fruit3/parts/header-shop.php
@@ -37,8 +37,11 @@
         </div>
     </div>
 </header>
+<?php $floating = get_query_var('floating_header_class'); ?>
 <nav class="nav-panel <?php echo plant_nav_position()?> -dropdown">
+    <?php if (!$floating): ?>
     <div class="nav-toggle nav-close"><em></em></div>
+    <?php endif; ?>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {
         wp_nav_menu(['theme_location' => 'mobile',]);

--- a/fruit3/parts/header-standard-right.php
+++ b/fruit3/parts/header-standard-right.php
@@ -40,8 +40,11 @@
         </div>
     </div>
 </header>
+<?php $floating = get_query_var('floating_header_class'); ?>
 <nav class="nav-panel -left -dropdown">
+    <?php if (!$floating): ?>
     <div class="nav-toggle nav-close"><em></em></div>
+    <?php endif; ?>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {
         wp_nav_menu(['theme_location' => 'mobile',]);

--- a/fruit3/parts/header-standard.php
+++ b/fruit3/parts/header-standard.php
@@ -16,8 +16,11 @@
         </div>
     </div>
 </header>
+<?php $floating = get_query_var('floating_header_class'); ?>
 <nav class="nav-panel -right -dropdown">
+    <?php if (!$floating): ?>
     <div class="nav-toggle nav-close"><em></em></div>
+    <?php endif; ?>
     <?php dynamic_sidebar('before_nav'); ?>
     <?php if (has_nav_menu('mobile')) {
         wp_nav_menu(['theme_location' => 'mobile',]);

--- a/fruit3/parts/header.php
+++ b/fruit3/parts/header.php
@@ -13,9 +13,7 @@
 </header>
 <?php $floating = get_query_var('floating_header_class'); ?>
 <nav class="nav-panel <?php echo plant_nav_position()?> -dropdown">
-    <?php if ($floating): ?>
-    <div class="nav-close"><em></em></div>
-    <?php else: ?>
+    <?php if (!$floating): ?>
     <div class="nav-toggle nav-close"><em></em></div>
     <?php endif; ?>
     <?php dynamic_sidebar('before_nav'); ?>


### PR DESCRIPTION
## Summary
- remove extra close button from mobile nav across header templates
- clean up nav close styling in SCSS and compiled CSS
- restore nav close button for non-floating headers so only floating headers rely on the main toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686645fda0648324b622beaeb54a5c9e